### PR TITLE
Created Docker layers for faster subsequent Kotlin builds

### DIFF
--- a/docker/kotlin.dockerfile
+++ b/docker/kotlin.dockerfile
@@ -1,6 +1,19 @@
 FROM gradle
 
 FROM gradle as builder
+
+# Copy sources that dont change much but contribute to the slowest part of the build.
+#   This will allow slow downloads to be cached as a docker layer
+COPY ./build.gradle.kts     /home/gradle/project/
+COPY ./gradle.properties    /home/gradle/project/
+COPY ./gradlew              /home/gradle/project/
+COPY ./gradlew.bat          /home/gradle/project/
+COPY ./settings.gradle.kts  /home/gradle/project/
+
+WORKDIR /home/gradle/project
+# Build all the code (including tests), but do not run the tests yet.
+RUN gradle build --info
+
 COPY ./ /home/gradle/project
 WORKDIR /home/gradle/project
 # Build all the code (including tests), but do not run the tests yet.


### PR DESCRIPTION
Downloading the JVM build artefacts for the Kotlin/Gradle build takes a long time. These artifacts rarely change. By copying them first, the downloads can be cached as an output of the docker layer. This allows changes to the Kotlin code to be made without invalidating the whole cache and forcing a full rebuild which will download the large build tool artefacts again.