### PR TITLE
Show exit message on failing tests too

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,12 +54,20 @@ services:
       dockerfile: ../../docker/kotlin.dockerfile
     command: >
       bash -c "
-      gradle test --rerun --info
-      && echo ' ---------------------------------------------------------------' 
-      && echo '    Tests have completed.'
-      && echo '    '
-      && echo '    Press ctrl+c to exit the docker process'
-      && echo ' ---------------------------------------------------------------' "    
+      {
+        gradle test --rerun --info &&
+        echo ' ---------------------------------------------------------------' && 
+        echo '    Tests have completed and passed.' && 
+        echo '    ' && 
+        echo '    Press ctrl+c to exit the docker process' && 
+        echo ' ---------------------------------------------------------------'
+      } || {
+        echo ' ---------------------------------------------------------------' && 
+        echo '    Tests have failed.' && 
+        echo '    ' && 
+        echo '    Press ctrl+c to exit the docker process' && 
+        echo ' ---------------------------------------------------------------'
+      } "
     environment:
         - PG_SERVER=testsql-postrges-server
     volumes:


### PR DESCRIPTION
Ensures that when tests pass we get an instructional output ("press ctrl+c to exit"), but also ensure that failures get the same instruction

Example from successful execution:

```
testsql-kotlin-tests     | BUILD SUCCESSFUL in 5s
testsql-kotlin-tests     | 4 actionable tasks: 2 executed, 2 up-to-date
testsql-kotlin-tests     | Some of the file system contents retained in the virtual file system are on file systems that Gradle doesn't support watching. The relevant state was discarded to ensure changes to these locations are properly detected. You can override this by explicitly enabling file system watching.
testsql-kotlin-tests     |  ---------------------------------------------------------------
testsql-kotlin-tests     |     Tests have completed and passed.
testsql-kotlin-tests     |
testsql-kotlin-tests     |     Press ctrl+c to exit the docker process
testsql-kotlin-tests     |  ---------------------------------------------------------------
```

Example from failed execution

```
testsql-kotlin-tests     | BUILD FAILED in 6s
testsql-kotlin-tests     |  ---------------------------------------------------------------
testsql-kotlin-tests     |     Tests have failed.
testsql-kotlin-tests     |
testsql-kotlin-tests     |     Press ctrl+c to exit the docker process
testsql-kotlin-tests     |  ---------------------------------------------------------------
```